### PR TITLE
Modify patch entry list address for Chinese localization

### DIFF
--- a/Resources/patches_database/database_zh-hans.plist
+++ b/Resources/patches_database/database_zh-hans.plist
@@ -10,43 +10,43 @@
 				<key>title</key>
 				<string>HP_840G系列电池更名补丁(来自宪武OC-Little)</string>
 				<key>url</key>
-				<string>https://raw.githubusercontent.com/mackie100/OCClocalizations/master/Resources/patches_database/patches/ACPI/Battery_renamed_patch/HP_840G_Series_renamed.plist</string>
+				<string>https://gitee.com/btwise/OCClocalizations/raw/master/Resources/patches_database/patches/ACPI/Battery_renamed_patch/HP_840G_Series_renamed.plist</string>
 			</dict>
 			<dict>
 				<key>title</key>
 				<string>HP_Pavilion系列电池更名补丁(来自宪武OC-Little)</string>
 				<key>url</key>
-				<string>https://raw.githubusercontent.com/mackie100/OCClocalizations/master/Resources/patches_database/patches/ACPI/Battery_renamed_patch/HP_Pavilion_Series_renamed.plist</string>
+				<string>https://gitee.com/btwise/OCClocalizations/raw/master/Resources/patches_database/patches/ACPI/Battery_renamed_patch/HP_Pavilion_Series_renamed.plist</string>
 			</dict>
 			<dict>
 				<key>title</key>
 				<string>HP_Z66_14ProG2电池更名补丁(来自宪武OC-Little)</string>
 				<key>url</key>
-				<string>https://raw.githubusercontent.com/mackie100/OCClocalizations/master/Resources/patches_database/patches/ACPI/Battery_renamed_patch/HP_Z66_14ProG2_renamed.plist</string>
+				<string>https://gitee.com/btwise/OCClocalizations/raw/master/Resources/patches_database/patches/ACPI/Battery_renamed_patch/HP_Z66_14ProG2_renamed.plist</string>
 			</dict>
 			<dict>
 				<key>title</key>
 				<string>Thinkpad系列电池基本更名补丁(来自宪武OC-Little)</string>
 				<key>url</key>
-				<string>https://raw.githubusercontent.com/mackie100/OCClocalizations/master/Resources/patches_database/patches/ACPI/Battery_renamed_patch/Thinkpad_series_basically_renamed.plist</string>
+				<string>https://gitee.com/btwise/OCClocalizations/raw/master/Resources/patches_database/patches/ACPI/Battery_renamed_patch/Thinkpad_series_basically_renamed.plist</string>
 			</dict>
 			<dict>
 				<key>title</key>
 				<string>ThinkPad系列电池禁用BAT1更名补丁(来自宪武OC-Little)</string>
 				<key>url</key>
-				<string>https://raw.githubusercontent.com/mackie100/OCClocalizations/master/Resources/patches_database/patches/ACPI/Battery_renamed_patch/ThinkPad_series_Disable_BAT1_devices_Renamed.plist</string>
+				<string>https://gitee.com/btwise/OCClocalizations/raw/master/Resources/patches_database/patches/ACPI/Battery_renamed_patch/ThinkPad_series_Disable_BAT1_devices_Renamed.plist</string>
 			</dict>
 			<dict>
 				<key>title</key>
 				<string>ThinkPad系列双物理电池更名补丁(来自宪武OC-Little)</string>
 				<key>url</key>
-				<string>https://raw.githubusercontent.com/mackie100/OCClocalizations/master/Resources/patches_database/patches/ACPI/Battery_renamed_patch/ThinkPad_series_dual_physical_battery_Notify_renamed.plist</string>
+				<string>https://gitee.com/btwise/OCClocalizations/raw/master/Resources/patches_database/patches/ACPI/Battery_renamed_patch/ThinkPad_series_dual_physical_battery_Notify_renamed.plist</string>
 			</dict>
 			<dict>
 				<key>title</key>
 				<string>ThinkPad系列Mutex重置为0更名补丁(来自宪武OC-Little)</string>
 				<key>url</key>
-				<string>https://raw.githubusercontent.com/mackie100/OCClocalizations/master/Resources/patches_database/patches/ACPI/Battery_renamed_patch/ThinkPad_series_Mutex_reset_to_0_Renamed.plist</string>
+				<string>https://gitee.com/btwise/OCClocalizations/raw/master/Resources/patches_database/patches/ACPI/Battery_renamed_patch/ThinkPad_series_Mutex_reset_to_0_Renamed.plist</string>
 			</dict>
 		</array>
 		<key>Rename Patches</key>
@@ -55,55 +55,55 @@
 				<key>title</key>
 				<string>ACPI_6D更名补丁(来自宪武OC-Little)</string>
 				<key>url</key>
-				<string>https://raw.githubusercontent.com/mackie100/OCClocalizations/master/Resources/patches_database/patches/ACPI/Rename_Patches/ACPI_6D_Renamed_patches.plist</string>
+				<string>https://gitee.com/btwise/OCClocalizations/raw/master/Resources/patches_database/patches/ACPI/Rename_Patches/ACPI_6D_Renamed_patches.plist</string>
 			</dict>
 			<dict>
 				<key>title</key>
 				<string>APCI_0D更名补丁(来自宪武OC-Little)</string>
 				<key>url</key>
-				<string>https://raw.githubusercontent.com/mackie100/OCClocalizations/master/Resources/patches_database/patches/ACPI/Rename_Patches/APCI_0D_Renamed_patches.plist</string>
+				<string>https://gitee.com/btwise/OCClocalizations/raw/master/Resources/patches_database/patches/ACPI/Rename_Patches/APCI_0D_Renamed_patches.plist</string>
 			</dict>
 			<dict>
 				<key>title</key>
 				<string>华擎 Z390 RTC补丁</string>
 				<key>url</key>
-				<string>https://raw.githubusercontent.com/mackie100/OCClocalizations/master/Resources/patches_database/patches/ACPI/Rename_Patches/Asrock_Z390_RTC_Patches.plist</string>
+				<string>https://gitee.com/btwise/OCClocalizations/raw/master/Resources/patches_database/patches/ACPI/Rename_Patches/Asrock_Z390_RTC_Patches.plist</string>
 			</dict>
 			<dict>
 				<key>title</key>
 				<string>亮度快捷键更名补丁(来自宪武OC-Little)</string>
 				<key>url</key>
-				<string>https://raw.githubusercontent.com/mackie100/OCClocalizations/master/Resources/patches_database/patches/ACPI/Rename_Patches/Brightness_hotkey_Renamed.plist</string>
+				<string>https://gitee.com/btwise/OCClocalizations/raw/master/Resources/patches_database/patches/ACPI/Rename_Patches/Brightness_hotkey_Renamed.plist</string>
 			</dict>
 			<dict>
 				<key>title</key>
 				<string>OSI和OSID重命名补丁(来自宪武OC-Little)</string>
 				<key>url</key>
-				<string>https://raw.githubusercontent.com/mackie100/OCClocalizations/master/Resources/patches_database/patches/ACPI/Rename_Patches/OSI_Renamed_patches.plist</string>
+				<string>https://gitee.com/btwise/OCClocalizations/raw/master/Resources/patches_database/patches/ACPI/Rename_Patches/OSI_Renamed_patches.plist</string>
 			</dict>
 			<dict>
 				<key>title</key>
 				<string>Lenovo笔记本PNLF重命名为XNLF(来自宪武OC-Little)</string>
 				<key>url</key>
-				<string>https://raw.githubusercontent.com/mackie100/OCClocalizations/master/Resources/patches_database/patches/ACPI/Rename_Patches/PNLF_renamed_XNLF_For_Lenovo_laptop.plist</string>
+				<string>https://gitee.com/btwise/OCClocalizations/raw/master/Resources/patches_database/patches/ACPI/Rename_Patches/PNLF_renamed_XNLF_For_Lenovo_laptop.plist</string>
 			</dict>
 			<dict>
 				<key>title</key>
 				<string>PTSWAK重命名补丁(来自宪武OC-Little)</string>
 				<key>url</key>
-				<string>https://raw.githubusercontent.com/mackie100/OCClocalizations/master/Resources/patches_database/patches/ACPI/Rename_Patches/PTSWAK_Renamed_patches.plist</string>
+				<string>https://gitee.com/btwise/OCClocalizations/raw/master/Resources/patches_database/patches/ACPI/Rename_Patches/PTSWAK_Renamed_patches.plist</string>
 			</dict>
 			<dict>
 				<key>title</key>
 				<string>禁用S3睡眠-S3重命名为XS3(来自宪武OC-Little)</string>
 				<key>url</key>
-				<string>https://raw.githubusercontent.com/mackie100/OCClocalizations/master/Resources/patches_database/patches/ACPI/Rename_Patches/S3_Renamed_XS3_for_Disable_S3_Sleep.plist</string>
+				<string>https://gitee.com/btwise/OCClocalizations/raw/master/Resources/patches_database/patches/ACPI/Rename_Patches/S3_Renamed_XS3_for_Disable_S3_Sleep.plist</string>
 			</dict>
 			<dict>
 				<key>title</key>
 				<string>睡眠按钮 LID重命名补丁(来自宪武OC-Little)</string>
 				<key>url</key>
-				<string>https://raw.githubusercontent.com/mackie100/OCClocalizations/master/Resources/patches_database/patches/ACPI/Rename_Patches/Sleep_button_LID_Renamed_patches.plist</string>
+				<string>https://gitee.com/btwise/OCClocalizations/raw/master/Resources/patches_database/patches/ACPI/Rename_Patches/Sleep_button_LID_Renamed_patches.plist</string>
 			</dict>
 		</array>
 	</dict>
@@ -113,31 +113,31 @@
 			<key>title</key>
 			<string>Broadcom无线蓝牙驱动预设加载顺序</string>
 			<key>url</key>
-			<string>https://raw.githubusercontent.com/mackie100/OCClocalizations/master/Resources/patches_database/patches/Kext/BCM_WIFI_Bluetooth_Drivers_Order_List.plist</string>
+			<string>https://gitee.com/btwise/OCClocalizations/raw/master/Resources/patches_database/patches/Kext/BCM_WIFI_Bluetooth_Drivers_Order_List.plist</string>
 		</dict>
 		<dict>
 			<key>title</key>
 			<string>I2C驱动预设加载顺序</string>
 			<key>url</key>
-			<string>https://raw.githubusercontent.com/mackie100/OCClocalizations/master/Resources/patches_database/patches/Kext/I2C_Drivers_List.plist</string>
+			<string>https://gitee.com/btwise/OCClocalizations/raw/master/Resources/patches_database/patches/Kext/I2C_Drivers_List.plist</string>
 		</dict>
 		<dict>
 			<key>title</key>
 			<string>Lilu-SMC-WEG-ALC驱动预设加载顺序</string>
 			<key>url</key>
-			<string>https://raw.githubusercontent.com/mackie100/OCClocalizations/master/Resources/patches_database/patches/Kext/Lilu-SMC-WEG-ALC-Drivers_Order_List.plist</string>
+			<string>https://gitee.com/btwise/OCClocalizations/raw/master/Resources/patches_database/patches/Kext/Lilu-SMC-WEG-ALC-Drivers_Order_List.plist</string>
 		</dict>
 		<dict>
 			<key>title</key>
 			<string>PS2Keyboard驱动预设加载顺序</string>
 			<key>url</key>
-			<string>https://raw.githubusercontent.com/mackie100/OCClocalizations/master/Resources/patches_database/patches/Kext/PS2Keyboard_Driver_Order_List.plist</string>
+			<string>https://gitee.com/btwise/OCClocalizations/raw/master/Resources/patches_database/patches/Kext/PS2Keyboard_Driver_Order_List.plist</string>
 		</dict>
 		<dict>
 			<key>title</key>
 			<string>PS2SmartKeyboard驱动预设加载顺序</string>
 			<key>url</key>
-			<string>https://raw.githubusercontent.com/mackie100/OCClocalizations/master/Resources/patches_database/patches/Kext/PS2SmartKeyboard_Drivers_Order_List.plist</string>
+			<string>https://gitee.com/btwise/OCClocalizations/raw/master/Resources/patches_database/patches/Kext/PS2SmartKeyboard_Drivers_Order_List.plist</string>
 		</dict>
 	</array>
 	<key>Kernel_patches</key>
@@ -146,13 +146,13 @@
 			<key>title</key>
 			<string>AMD Ryzen系列内核补丁</string>
 			<key>url</key>
-			<string>https://raw.githubusercontent.com/mackie100/OCClocalizations/master/Resources/patches_database/patches/Kernel/AMD_Ryzen_series_Kernel_patches.plist</string>
+			<string>https://gitee.com/btwise/OCClocalizations/raw/master/Resources/patches_database/patches/Kernel/AMD_Ryzen_series_Kernel_patches.plist</string>
 		</dict>
 		<dict>
 			<key>title</key>
 			<string>AMD AM4和FX系列内核补丁</string>
 			<key>url</key>
-			<string>https://raw.githubusercontent.com/mackie100/OCClocalizations/master/Resources/patches_database/patches/Kernel/AMD_AM4_and_FX_series_Kernel_patches.plist</string>
+			<string>https://gitee.com/btwise/OCClocalizations/raw/master/Resources/patches_database/patches/Kernel/AMD_AM4_and_FX_series_Kernel_patches.plist</string>
 		</dict>
 	</array>
 </dict>


### PR DESCRIPTION
To load the patch list, you can use the relative path, or downloaded to  local computer, rather than use absolute paths, avoid cannot access raw.githubusercontent.com timeout caused by failed!